### PR TITLE
test: Disperse large volume data [TC8.3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+log/
+kzgrs/
+cluster_config/cfgsync.yaml

--- a/cluster_config/cfgsync-template.yaml
+++ b/cluster_config/cfgsync-template.yaml
@@ -8,9 +8,9 @@ active_slot_coeff: 0.9
 
 # DaConfig related parameters
 subnetwork_size: {{ subnet_size }}
-dispersal_factor: 2
+dispersal_factor: {{ dispersal_factor }}
 num_samples: 1
-num_subnets: 2
+num_subnets: {{ subnet_size }}
 old_blobs_check_interval_secs: 5
 blobs_validity_duration_secs: 60
 global_params_path: "/kzgrs_test_params"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ click==8.1.7
 distlib==0.3.8
 docker==7.0.0
 execnet==2.0.2
+Faker==37.0.0
 filelock==3.13.1
 identify==2.5.33
 idna==3.7

--- a/src/api_clients/base_client.py
+++ b/src/api_clients/base_client.py
@@ -9,6 +9,7 @@ logger = get_custom_logger(__name__)
 class BaseClient:
     def make_request(self, method, url, headers=None, data=None):
         self.log_request_as_curl(method, url, headers, data)
+        self.print_request_size(data)
         response = requests.request(method.upper(), url, headers=headers, data=data, timeout=API_REQUEST_TIMEOUT)
         try:
             response.raise_for_status()
@@ -35,3 +36,8 @@ class BaseClient:
         headers_str_for_log = " ".join([f'-H "{key}: {value}"' for key, value in headers.items()]) if headers else ""
         curl_cmd = f"curl -v -X {method.upper()} \"{url}\" {headers_str_for_log} -d '{data}'"
         logger.info(curl_cmd)
+
+    def print_request_size(self, data):
+        body_size = len(data) if data else 0
+        body_kb = body_size / 1024
+        logger.debug(f"Body size: {body_kb:.2f}kB")

--- a/src/libs/common.py
+++ b/src/libs/common.py
@@ -54,6 +54,25 @@ def generate_random_bytes(n=31):
     return os.urandom(n)
 
 
+def generate_text_data(target_size):
+    words = ["lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "sed", "do", "eiusmod", "tempor"]
+    result = []
+
+    current_size = 0
+    while current_size <= target_size:
+        word = random.choice(words)
+        result.append(word)
+        current_size = len(" ".join(result).encode("utf-8"))
+
+    text_data = " ".join(result)
+    while len(text_data.encode("utf-8")) > target_size:
+        text_data = text_data[:-1]
+
+    logger.debug(f"Raw data size: {len(text_data.encode("utf-8"))}\n\t{text_data}")
+
+    return text_data
+
+
 def add_padding(orig_bytes):
     """
     Pads a list of bytes (integers in [0..255]) using a PKCS#7-like scheme:

--- a/src/libs/common.py
+++ b/src/libs/common.py
@@ -1,8 +1,11 @@
+import math
 import random
 import string
 import uuid
 from datetime import datetime
 from time import sleep
+
+from faker import Faker
 from src.libs.custom_logger import get_custom_logger
 import os
 import allure
@@ -55,17 +58,11 @@ def generate_random_bytes(n=31):
 
 
 def generate_text_data(target_size):
-    words = ["lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "sed", "do", "eiusmod", "tempor"]
-    result = []
+    faker = Faker()
+    text_data = faker.text(max_nb_chars=math.floor(target_size * 1.2))  # 20% more than target size
+    text_data = " ".join(text_data.splitlines())  # remove newlines
 
-    current_size = 0
-    while current_size <= target_size:
-        word = random.choice(words)
-        result.append(word)
-        current_size = len(" ".join(result).encode("utf-8"))
-
-    text_data = " ".join(result)
-    while len(text_data.encode("utf-8")) > target_size:
+    while len(text_data.encode("utf-8")) > target_size:  # trim to exact size
         text_data = text_data[:-1]
 
     logger.debug(f"Raw data size: {len(text_data.encode("utf-8"))}\n\t{text_data}")

--- a/src/steps/common.py
+++ b/src/steps/common.py
@@ -72,7 +72,13 @@ class StepsCommon:
     @pytest.fixture(scope="function")
     def setup_4_node_cluster(self, request):
         logger.debug(f"Running fixture setup: {inspect.currentframe().f_code.co_name}")
-        prepare_cluster_config(4)
+
+        if hasattr(request, "param"):
+            subnet_size = request.param
+        else:
+            subnet_size = 2
+
+        prepare_cluster_config(4, subnet_size)
         self.node1 = NomosNode(CFGSYNC, "cfgsync")
         self.node2 = NomosNode(NOMOS, "nomos_node_0")
         self.node3 = NomosNode(NOMOS, "nomos_node_1")

--- a/src/steps/da.py
+++ b/src/steps/da.py
@@ -76,11 +76,12 @@ class StepsDataAvailability(StepsCommon):
     def get_data_range(self, node, app_id, start, end, client_node=None, **kwargs):
 
         timeout_duration = kwargs.get("timeout_duration", 65)
+        interval = kwargs.get("interval", 0.1)
         send_invalid = kwargs.get("send_invalid", False)
 
         query = prepare_get_range_request(app_id, start, end)
 
-        @retry(stop=stop_after_delay(timeout_duration), wait=wait_fixed(0.1), reraise=True)
+        @retry(stop=stop_after_delay(timeout_duration), wait=wait_fixed(interval), reraise=True)
         def get_range():
             response = []
             try:

--- a/src/steps/da.py
+++ b/src/steps/da.py
@@ -29,6 +29,9 @@ def prepare_get_range_request(app_id, start_index, end_index):
 
 
 def response_contains_data(response):
+    if response is None:
+        return False
+
     for index, blobs in response:
         if len(blobs) != 0:
             return True

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -14,7 +14,7 @@ class TestLargeVolume(StepsDataAvailability):
         "setup_4_node_cluster,raw_data_size",
         [
             ({"subnet_size": 4, "dispersal_factor": 1}, 50),  # => ~~0.5kB
-            ({"subnet_size": 64, "dispersal_factor": 32}, 800),  # => ~~ 4kB
+            ({"subnet_size": 64, "dispersal_factor": 16}, 800),  # => ~~ 4kB
             ({"subnet_size": 2048, "dispersal_factor": 512}, 51 * 1024),  # => ~~244kB, spec limit: 248kB
         ],
         indirect=["setup_4_node_cluster"],

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -1,0 +1,59 @@
+import random
+import pytest
+
+from src.libs.common import to_app_id, to_index
+from src.libs.custom_logger import get_custom_logger
+from src.steps.da import StepsDataAvailability
+
+logger = get_custom_logger(__name__)
+
+
+def generate_large_text_data(size):
+    """Generate large text data with random words"""
+    words = ["lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "sed", "do", "eiusmod", "tempor"]
+
+    result = []
+    target_size = size
+    current_size = 0
+
+    while current_size <= target_size:
+        word = random.choice(words)
+        result.append(word)
+        current_size = len(" ".join(result).encode("utf-8"))
+
+    data = " ".join(result)
+
+    while len(data.encode("utf-8")) > target_size:
+        data = data[:-1]
+
+    logger.debug(f"Raw data size: {len(data.encode("utf-8"))}\n\t{data}")
+
+    return data
+
+
+class TestLargeVolume(StepsDataAvailability):
+
+    @pytest.mark.usefixtures("setup_4_node_cluster")
+    @pytest.mark.parametrize("setup_4_node_cluster", [2048], indirect=True)
+    @pytest.mark.parametrize(
+        "raw_data_size",
+        [
+            50,
+            # 70,
+            # 256,
+            # 10 * 1024,
+            # 100 * 1024,
+            # 256 * 1024,
+        ],
+    )
+    def test_large_volume_dispersal(self, raw_data_size):
+        data = generate_large_text_data(raw_data_size)
+
+        try:
+            response = self.disperse_data(data, to_app_id(1), to_index(0), timeout_duration=0)
+            if response.status_code != 200:
+                print(response)
+        except Exception as ex:
+            raise Exception(f"Dispersal was not successful with error {ex}")
+
+        assert response.status_code == 200

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -30,8 +30,7 @@ class TestLargeVolume(StepsDataAvailability):
         assert response.status_code == 200
 
         delay(5)
-        rcv_data = self.get_data_range(self.node2, to_app_id(1), to_index(0), to_index(5), timeout_duration=20, interval=1)
-        assert rcv_data is not None
+        self.get_data_range(self.node2, to_app_id(1), to_index(0), to_index(5), timeout_duration=20, interval=1)
 
     @pytest.mark.usefixtures("setup_2_node_cluster")
     @pytest.mark.parametrize(

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -15,7 +15,7 @@ class TestLargeVolume(StepsDataAvailability):
         [
             ({"subnet_size": 4, "dispersal_factor": 1}, 50),  # => ~~0.5kB
             ({"subnet_size": 64, "dispersal_factor": 16}, 800),  # => ~~ 4kB
-            ({"subnet_size": 2048, "dispersal_factor": 512}, 51 * 1024),  # => ~~244kB, spec limit: 248kB
+            ({"subnet_size": 2048, "dispersal_factor": 512}, 53 * 1024),  # => ~~254kB, spec limit: 256kB
         ],
         indirect=["setup_4_node_cluster"],
     )

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.libs.common import generate_text_data, to_app_id, to_index
+from src.libs.common import delay, generate_text_data, to_app_id, to_index
 from src.libs.custom_logger import get_custom_logger
 from src.steps.da import StepsDataAvailability
 
@@ -13,7 +13,8 @@ class TestLargeVolume(StepsDataAvailability):
     @pytest.mark.parametrize(
         "setup_4_node_cluster,raw_data_size",
         [
-            ({"subnet_size": 32, "dispersal_factor": 8}, 70),  # => ~~0.58kB
+            ({"subnet_size": 4, "dispersal_factor": 1}, 50),  # => ~~0.5kB
+            ({"subnet_size": 64, "dispersal_factor": 32}, 800),  # => ~~ 4kB
             ({"subnet_size": 2048, "dispersal_factor": 512}, 51 * 1024),  # => ~~244kB, spec limit: 248kB
         ],
         indirect=["setup_4_node_cluster"],
@@ -27,3 +28,18 @@ class TestLargeVolume(StepsDataAvailability):
             raise Exception(f"Dispersal was not successful with error {ex}")
 
         assert response.status_code == 200
+
+        delay(5)
+        rcv_data = self.get_data_range(self.node2, to_app_id(1), to_index(0), to_index(5), timeout_duration=20, interval=1)
+        assert rcv_data is not None
+
+    @pytest.mark.usefixtures("setup_2_node_cluster")
+    @pytest.mark.parametrize(
+        "setup_2_node_cluster,raw_data_size",
+        [
+            ({"subnet_size": 2, "dispersal_factor": 2}, 50),
+        ],
+        indirect=["setup_2_node_cluster"],
+    )
+    def test_large_volume_dispersal_2node(self, raw_data_size):
+        self.test_large_volume_dispersal(raw_data_size)

--- a/tests/dos_robustness/test_large_volume.py
+++ b/tests/dos_robustness/test_large_volume.py
@@ -1,58 +1,28 @@
-import random
 import pytest
 
-from src.libs.common import to_app_id, to_index
+from src.libs.common import generate_text_data, to_app_id, to_index
 from src.libs.custom_logger import get_custom_logger
 from src.steps.da import StepsDataAvailability
 
 logger = get_custom_logger(__name__)
 
 
-def generate_large_text_data(size):
-    """Generate large text data with random words"""
-    words = ["lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit", "sed", "do", "eiusmod", "tempor"]
-
-    result = []
-    target_size = size
-    current_size = 0
-
-    while current_size <= target_size:
-        word = random.choice(words)
-        result.append(word)
-        current_size = len(" ".join(result).encode("utf-8"))
-
-    data = " ".join(result)
-
-    while len(data.encode("utf-8")) > target_size:
-        data = data[:-1]
-
-    logger.debug(f"Raw data size: {len(data.encode("utf-8"))}\n\t{data}")
-
-    return data
-
-
 class TestLargeVolume(StepsDataAvailability):
 
     @pytest.mark.usefixtures("setup_4_node_cluster")
-    @pytest.mark.parametrize("setup_4_node_cluster", [2048], indirect=True)
     @pytest.mark.parametrize(
-        "raw_data_size",
+        "setup_4_node_cluster,raw_data_size",
         [
-            50,
-            # 70,
-            # 256,
-            # 10 * 1024,
-            # 100 * 1024,
-            # 256 * 1024,
+            ({"subnet_size": 32, "dispersal_factor": 8}, 70),  # => ~~0.58kB
+            ({"subnet_size": 2048, "dispersal_factor": 512}, 51 * 1024),  # => ~~244kB, spec limit: 248kB
         ],
+        indirect=["setup_4_node_cluster"],
     )
     def test_large_volume_dispersal(self, raw_data_size):
-        data = generate_large_text_data(raw_data_size)
+        data = generate_text_data(raw_data_size)
 
         try:
             response = self.disperse_data(data, to_app_id(1), to_index(0), timeout_duration=0)
-            if response.status_code != 200:
-                print(response)
         except Exception as ex:
             raise Exception(f"Dispersal was not successful with error {ex}")
 


### PR DESCRIPTION
## PR Details
Test if dispersing large volume data is successful and system handles it. Current spec limit for 2048 subnets is 256 kB. 

Added cases:
```
nodes: 2, subnet_size: 2, dispersal_factor:2, request_size: ~~0.5kB

result: ✅


nodes: 4, subnet_size: 4, dispersal_factor:1, request_size: ~~0.5kB

result: dispersion ✅, retrieval ❌ 


nodes: 4, subnet_size: 64, dispersal_factor:32, request_size: ~~4kB

result: dispersion ✅, retrieval ❌ 


nodes: 4, subnet_size: 2048, dispersal_factor:512, request_size: ~~244kB

result: dispersion (timeout)  ❌ , retrieval ❌ 
```


## Issues reported:

<!-- Issues found while working for this PR --> 
