### PR TITLE
fix: Padding error handling

### DIFF
--- a/tests/data_integrity/test_data_integrity.py
+++ b/tests/data_integrity/test_data_integrity.py
@@ -24,7 +24,7 @@ class TestDataIntegrity(StepsDataAvailability):
             rcv_data = self.get_data_range(node, to_app_id(1), to_index(0), to_index(5))
             rcv_data_json = json.dumps(rcv_data)
 
-            reconstructed_data = NomosCli(command="reconstruct").run(input_values=[rcv_data_json])
+            reconstructed_data = NomosCli(command="reconstruct").run(input_values=[rcv_data_json], decode_only=True)
 
             if DATA_TO_DISPERSE[1] == reconstructed_data:
                 test_results.append(node.name())

--- a/tests/data_integrity/test_data_integrity.py
+++ b/tests/data_integrity/test_data_integrity.py
@@ -47,7 +47,7 @@ class TestDataIntegrity(StepsDataAvailability):
             rcv_data = self.get_data_range(node, to_app_id(1), to_index(0), to_index(5))
             rcv_data_json = json.dumps(rcv_data)
 
-            reconstructed_data = NomosCli(command="reconstruct").run(input_values=[rcv_data_json])
+            reconstructed_data = NomosCli(command="reconstruct").run(input_values=[rcv_data_json], decode_only=True)
 
             if DATA_TO_DISPERSE[1] == reconstructed_data:
                 test_results.append(node.name())

--- a/tests/dos_robustness/test_high_load_dos.py
+++ b/tests/dos_robustness/test_high_load_dos.py
@@ -158,9 +158,10 @@ class TestHighLoadDos(StepsDataAvailability):
                 response = self.disperse_data(
                     DATA_TO_DISPERSE[6], to_app_id(1), to_index(0), client_node=dispersal_cl, timeout_duration=0, send_invalid=invalid
                 )
-                assert response.status_code == 200, f"Dispersal failed with status code {response.status_code}"
+                assert response.status_code == 200, f"Dispersal failed with unexpected status code {response.status_code}"
                 successful_dispersals += 1
-            except AssertionError:
+            except Exception as ex:
+                assert "422" in str(ex), f"Unexpected error: {ex}"
                 if not invalid:
                     unsuccessful_dispersals += 1
 


### PR DESCRIPTION
## PR Details

This PR fixes two problems:
- Padding for new configuration defaults - 4node cluster.
- Test error handling when invalid request is sent to Nomos node and 422 http error code is expected as response.


